### PR TITLE
Change `Sequence` type annotations to `list` when returning `_allrows()`

### DIFF
--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -1383,7 +1383,7 @@ class Result(_WithKeys, ResultInternal[Row[Unpack[_Ts]]]):
 
         return self._manyrow_getter(self, size)
 
-    def all(self) -> Sequence[Row[Unpack[_Ts]]]:
+    def all(self) -> List[Row[Unpack[_Ts]]]:
         """Return all rows in a sequence.
 
         Closes the result set after invocation.   Subsequent invocations
@@ -1790,7 +1790,7 @@ class ScalarResult(FilterResult[_R]):
         """
         return self._manyrow_getter(self, size)
 
-    def all(self) -> Sequence[_R]:
+    def all(self) -> List[_R]:
         """Return all scalar values in a sequence.
 
         Equivalent to :meth:`_engine.Result.all` except that
@@ -2094,7 +2094,7 @@ class MappingResult(_WithKeys, FilterResult[RowMapping]):
 
         return self._manyrow_getter(self, size)
 
-    def all(self) -> Sequence[RowMapping]:
+    def all(self) -> List[RowMapping]:
         """Return all scalar values in a sequence.
 
         Equivalent to :meth:`_engine.Result.all` except that


### PR DESCRIPTION
The methods modified in this PR directly return `self._allrows()`, inherited from `ResultInternal._allrows()`, which is annotated as returning a `list` object: https://github.com/sqlalchemy/sqlalchemy/blob/8f47774de91b18e8b9a21d39662bffd239785b4e/lib/sqlalchemy/engine/result.py#L545

However, these methods themselves are annotated as returning a more generic `Sequence` object. 

This PR changes the annotations of these methods to match the type returned by `_allrows`.

Sidenote: I used `typing.List` instead of the built-in `list` to remain consistent with the other type annotations here, but it's worth noting that `typing.List` was deprecated in Python 3.9: https://docs.python.org/3/library/typing.html#typing.List - I assume it's still being used here to maintain backwards compatibility

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
